### PR TITLE
feat: dodane wyświetlanie adresu email na stronie organizacji 

### DIFF
--- a/organizations/testowa.yaml
+++ b/organizations/testowa.yaml
@@ -11,8 +11,9 @@ dostawa:
   ulica: Testowa 1
   kod: 00-000
   miasto: Warszawa
-  kod_paczkomatu: WAW01M
   telefon: 22 000 00 00
+  email: kontakt@testowa.pl
+  kod_paczkomatu: WAW01M
   dodatkowe_informacje: Dostawa tylko w godzinach 9:00-17:00, proszę dzwonić przed przyjściem
 
 produkty:

--- a/site/templates/organization.html
+++ b/site/templates/organization.html
@@ -101,8 +101,52 @@
 
         <!-- Right column: Paczkomat and Phone -->
         <div class="pb-4">
-          {% if data.dostawa.kod_paczkomatu %}
           <div class="pb-4">
+            <h2 class="text-sectionTitle mb-2 pl-1 text-lg">Telefon dla kuriera</h2>
+            <div
+              class="copyable-field-standalone"
+              role="button"
+              tabindex="0"
+              onclick="copyText(this)"
+              onkeydown="handleCopyKeydown(event, this)"
+            >
+              {{ data.dostawa.telefon }}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                stroke-width="1.5"
+                stroke="currentColor"
+                class="size-6"
+              >
+                <use href="#icon-copy"></use>
+              </svg>
+            </div>
+          </div>
+
+          <div class="pb-4">
+            <h2 class="text-sectionTitle mb-2 pl-1 text-lg">Email dla kuriera</h2>
+            <div
+              class="copyable-field-standalone"
+              role="button"
+              tabindex="0"
+              onclick="copyText(this)"
+              onkeydown="handleCopyKeydown(event, this)"
+            >
+              {{ data.dostawa.email }}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                stroke-width="1.5"
+                stroke="currentColor"
+                class="size-6"
+              >
+                <use href="#icon-copy"></use>
+              </svg>
+            </div>
+          </div>
+
+          {% if data.dostawa.kod_paczkomatu %}
+          <div>
             <h2 class="text-sectionTitle mb-2 pl-1 text-lg">Kod paczkomatu</h2>
             <div
               class="copyable-field-standalone"
@@ -125,28 +169,6 @@
             </div>
           </div>
           {% endif %}
-
-          <div>
-            <h2 class="text-sectionTitle mb-2 pl-1 text-lg">Telefon dla kuriera</h2>
-            <div
-              class="copyable-field-standalone"
-              role="button"
-              tabindex="0"
-              onclick="copyText(this)"
-              onkeydown="handleCopyKeydown(event, this)"
-            >
-              {{ data.dostawa.telefon }}
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                stroke-width="1.5"
-                stroke="currentColor"
-                class="size-6"
-              >
-                <use href="#icon-copy"></use>
-              </svg>
-            </div>
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Dla wysyłek często potrzebny jest nie tylko numer telefonu do organizacji, ale także adres email, na który trafiają powiadomienia od firmy kurierskiej. Adres email był już w formularzu, ale nie był wyświetlany na stronie. 