### PR TITLE
feat: Domyślnie pusta lista produktów dla zgłaszanej organizacji

### DIFF
--- a/.github/scripts/organization.yaml.j2
+++ b/.github/scripts/organization.yaml.j2
@@ -17,6 +17,3 @@ dostawa:
   dodatkowe_informacje:{% if organization.additional_info %} {{ organization.additional_info }}{% endif %}
 
 produkty:
-  - nazwa: Testowy produkt
-    link: http://example.com
-


### PR DESCRIPTION
Nowe organizacje tworzone przez automatyzację ze zgłoszeń w Issues nie muszą już mieć żadnego produktu dodanego na start (nawet przykładowego), dlatego nie jest to potrzebne w szablonie yaml