### PR TITLE
Poprawa literówki i przeformułowanie tekstu w profilu Czarnej Owcy Pana Kota

### DIFF
--- a/organizations/czarnej-owcy.yaml
+++ b/organizations/czarnej-owcy.yaml
@@ -14,7 +14,7 @@ dostawa:
   telefon: 882639810
   email: tomek@czarnaowca.org
   kod_paczkomatu: AL532KR1
-  dodatkowe_informacje: W przypadku wysyłki nie do paczkomatu prossimy o wcześniejszy kontakt telefoniczny.
+  dodatkowe_informacje: W przypadku wysyłki inną metodą niż do paczkomatu, prosimy o wcześniejszy kontakt telefoniczny.
 
 produkty:
   - nazwa: 'Karma dla ptaków MDM BP, 25 kg'


### PR DESCRIPTION
Przeformułowano wartość klucza dodatkowe_informacje, by była bardziej zrozumiała; przy okazji usunięto literówkę.